### PR TITLE
Optimize existing dump logging behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,149 @@
 # go-logger
-This module supposes to be a simple and easy Golang logging module.
+This module is a simple and easy Golang logging module.
 
 # Quick Start
 ## Install
 ~~~
 go get github.com/breeze7086/go-logger
 ~~~
-## Sample
+
+## Print logs to stdout
 ~~~
-import github.com/breeze7086/go-logger
+package main
+
+import "github.com/breeze7086/go-logger"
 
 func main() {
   logger.SetSeverity(logger.DEBUG)
   logger.SetTimeformat("2006/01/02 15:04:05")
-  logger.DebugPrintln("This a DEBUG log")
-  logger.InfoPrintln("This is a INFO log")
+
+  logger.DebugPrintln("This is a DEBUG log")
+  logger.InfoPrintln("This is an INFO log")
+  logger.WarnPrintf("This is a %s log", "WARN")
+  logger.ErrorPrintf("This is an %s log", "ERROR")
 }
 ~~~
+
 ## Output
 ~~~
 Set the log level to DEBUG
-file:main.go line:10 2022/03/24 11:56:11 [DEBUG] This a DEBUG log
-2022/03/24 11:56:11 [INFO] This is a INFO log
+file:main.go line:10 2022/03/24 11:56:11 [DEBUG] This is a DEBUG log
+2022/03/24 11:56:11 [INFO] This is an INFO log
+2022/03/24 11:56:11 [WARN] This is a WARN log
+2022/03/24 11:56:11 [ERROR] This is an ERROR log
 ~~~
 
 # Change output from stdout to a file
-The default logger instance will use *stdout* as default output location.  
-However, go-logger supports to change the output stream to other location.  
-In this case, you need to construct the logger instance by yourself to specify the output location.  
-## File
+The default logger instance uses *stdout* as the output location.
+You can create a logger instance with a custom `io.Writer` to write logs elsewhere.
+
+## File output
 ~~~
-import github.com/breeze7086/go-logger
+package main
+
+import (
+  "log"
+  "os"
+
+  "github.com/breeze7086/go-logger"
+)
 
 func main() {
-  // Create a file
   f, err := os.Create("test.log")
-	if err != nil {
-		t.Fatal(err)
-	}
+  if err != nil {
+    log.Fatal(err)
+  }
+  defer f.Close()
 
-  defer func() {
-    if err := f.Close(); err != nil {
-	  t.Fatal(err)
-	}
-  }()
-
-  // Create an logger instance with some initial parameters
-  // The third parameter "f" is the output flow you will use via this logger instance
-  // You can also set the output flow by calling the instance funtion l.SetOutflow(outflow io.Writer)
-  l := NewLogger(DEBUG, "2006-01-02 15:04:05", f)
-  l.DebugPrintln("This is the println DEBUG testing string")
-  l.InfoPrintln("This is the println INFO testing string")
+  l := logger.NewLogger(logger.DEBUG, "2006-01-02 15:04:05", f)
+  l.DebugPrintln("This is a DEBUG log")
+  l.InfoPrintln("This is an INFO log")
 }
 ~~~
-## Output  
-Logs will be generated in a file *test.log*
+
+## Output
+Logs will be generated in a file *test.log*.
 ~~~
 $ cat test.log
 file:main.go line:17 2022-03-24 13:27:07 [DEBUG] This is a DEBUG log
-2022-03-24 13:27:07 [INFO] This is a INFO log
+2022-03-24 13:27:07 [INFO] This is an INFO log
+~~~
+
+# Mask sensitive values
+Use `Mask` when you need to hide a sensitive value before printing it.
+~~~
+package main
+
+import (
+  "os"
+
+  "github.com/breeze7086/go-logger"
+)
+
+func main() {
+  l := logger.NewLogger(logger.INFO, "2006-01-02 15:04:05", os.Stdout)
+  l.InfoPrintf("password=%s", l.Mask("secret-password"))
+}
+~~~
+
+## Output
+~~~
+2022-03-24 13:27:07 [INFO] password=******
+~~~
+
+# Dump structs and maps
+Use `Dump` to print structs, maps, slices, and arrays in a readable format.
+`Dump` uses the logger output flow, so it works with stdout, files, and other custom writers.
+
+~~~
+package main
+
+import "github.com/breeze7086/go-logger"
+
+type ServiceConfig struct {
+  Service string
+  Enabled bool
+  Ports   []int
+}
+
+func main() {
+  logger.Dump(ServiceConfig{
+    Service: "go-logger",
+    Enabled: true,
+    Ports:   []int{8080, 8443},
+  })
+
+  logger.Dump(map[string]interface{}{
+    "service": "go-logger",
+    "enabled": true,
+  })
+}
+~~~
+
+# Send logs to syslog
+Create a logger instance and call `EnableSyslog` to send logs to the local logging system.
+If syslog is not available, the logger keeps its previous output flow.
+
+~~~
+package main
+
+import (
+  "os"
+
+  "github.com/breeze7086/go-logger"
+)
+
+func main() {
+  l := logger.NewLogger(logger.INFO, "2006-01-02 15:04:05", os.Stdout)
+  l.EnableSyslog("go-logger")
+  l.InfoPrintln("This log is sent to syslog when syslog is available")
+}
 ~~~
 
 # What's next
 | Feature | Status |
 | ------- |---|
-| Support to mask sensitive information when do the print out | ✅ |
-| Support to send logs to a Kafka topic |   |
-| Support to send logs to local logging system(syslog, rsyslog) | ✅ |
-| Function "Dump" to gracefully print out a struct or a map | ✅ |
+| Support to mask sensitive information when do the print out | Done |
+| Support to send logs to a Kafka topic | Planned |
+| Support to send logs to local logging system(syslog, rsyslog) | Done |
+| Function "Dump" to gracefully print out a struct or a map | Done |

--- a/logger.go
+++ b/logger.go
@@ -112,6 +112,18 @@ func (l *loggerT) Mask(infoToMask string) string {
 	return "******"
 }
 
+func dumpString(v interface{}) string {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err == nil {
+		return string(out)
+	}
+	return fmt.Sprintf("%#v", v)
+}
+
+func (l *loggerT) Dump(v interface{}) {
+	l.InfoPrintln(dumpString(v))
+}
+
 func (l *loggerT) setTimeFormat(timeFormat string) {
 	l.timeFormat = timeFormat
 }
@@ -165,15 +177,6 @@ func (l *loggerT) logln(level logLevel, v ...interface{}) {
 	}
 }
 
-func (l *loggerT) Dump(v interface{}) {
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		fmt.Printf("Error dump v: %v\n", v)
-		return
-	}
-	fmt.Println(string(b))
-}
-
 func (l *loggerT) DebugPrintf(format string, v ...interface{}) {
 	l.logf(DEBUG, format, v...)
 }
@@ -214,16 +217,6 @@ func (l *loggerT) ErrorPrintln(v ...interface{}) {
 func (l *loggerT) FatalPrintln(v ...interface{}) {
 	l.logln(FATAL, v...)
 	os.Exit(1)
-}
-
-// Dump std Dump function
-func Dump(v interface{}) {
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		fmt.Printf("Error dump v: %v\n", v)
-		return
-	}
-	fmt.Println(string(b))
 }
 
 // DebugPrintf std Debug printf function
@@ -276,4 +269,9 @@ func ErrorPrintln(v ...interface{}) {
 func FatalPrintln(v ...interface{}) {
 	std.FatalPrintln(v...)
 	os.Exit(1)
+}
+
+// Dump std function to print structs, maps, slices, and arrays in a readable format.
+func Dump(v interface{}) {
+	std.Dump(v)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,7 +1,9 @@
 package logger
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -59,6 +61,31 @@ func Test_File_Output(t *testing.T) {
 	l.ErrorPrintf("This is the printf ERROR testing string")
 }
 
+func Test_Dump(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(INFO, "2006-01-02 15:04:05", &buf)
+
+	l.Dump(map[string]interface{}{
+		"name":    "go-logger",
+		"enabled": true,
+	})
+
+	got := buf.String()
+	if !strings.Contains(got, "[INFO]") {
+		t.Fatalf("expected INFO prefix in dump output, got %q", got)
+	}
+	if !strings.Contains(got, `"name": "go-logger"`) {
+		t.Fatalf("expected formatted map in dump output, got %q", got)
+	}
+
+	type config struct {
+		Name string
+	}
+	if got := dumpString(config{Name: "go-logger"}); !strings.Contains(got, `"Name": "go-logger"`) {
+		t.Fatalf("expected formatted struct, got %q", got)
+	}
+}
+
 func Test_Syslog_Output(t *testing.T) {
 	std.EnableSyslog("syslog_test")
 	std.SetSeverity(DEBUG)
@@ -72,22 +99,4 @@ func Test_Syslog_Output(t *testing.T) {
 	InfoPrintf("This is the printf INFO testing string")
 	WarnPrintf("This is the printf WARN testing string")
 	ErrorPrintf("This is the printf ERROR testing string")
-}
-
-func Test_Dump(t *testing.T) {
-	type Student struct {
-		Name    string
-		Age     int
-		Hobbies []string
-		Meta    map[string]string
-	}
-
-	p := Student{
-		Name:    "Mayer",
-		Age:     8,
-		Hobbies: []string{"reading", "sport"},
-		Meta:    map[string]string{"gender": "male", "specialty": "go"},
-	}
-
-	Dump(p)
 }

--- a/syslog.go
+++ b/syslog.go
@@ -9,12 +9,14 @@ var logLevelMap = map[logLevel]syslog.Priority{
 	INFO:  syslog.LOG_INFO,
 	WARN:  syslog.LOG_WARNING,
 	ERROR: syslog.LOG_ERR,
+	FATAL: syslog.LOG_CRIT,
 }
 
 func (l *loggerT) EnableSyslog(appTag string) {
 	writer, err := syslog.Dial("", "", logLevelMap[l.level], appTag)
 	if err != nil {
 		ErrorPrintf("Can't connect to syslog, %v", err)
+		return
 	}
 
 	l.outflow = writer


### PR DESCRIPTION
## Summary
- Route Dump through the logger output flow instead of printing directly to stdout
- Keep syslog failures from replacing the output writer
- Expand README usage examples for stdout, file output, masking, Dump, and syslog

## Tests
- go test ./...